### PR TITLE
stop things from crashing on nil unwrap

### DIFF
--- a/Sources/ScClient/client.swift
+++ b/Sources/ScClient/client.swift
@@ -68,13 +68,12 @@ public class ScClient : Listener, WebSocketDelegate {
                         authToken = ClientUtils.getAuthToken(message: messageObject)
                         self.onSetAuthentication?(self, authToken)
                     case .ackReceive:
-                        
-                        handleEmitAck(id: rid!, error: error as AnyObject, data: data as AnyObject)
+                        handleEmitAck(id: rid ?? -1, error: error as AnyObject, data: data as AnyObject)
                     case .event:
-                        if hasEventAck(eventName: eventName!) {
-                            handleOnAckListener(eventName: eventName!, data: data as AnyObject, ack: self.ack(cid: cid!))
+                        if hasEventAck(eventName: eventName ?? "") {
+                            handleOnAckListener(eventName: eventName ?? "", data: data as AnyObject, ack: self.ack(cid: cid!))
                         } else {
-                            handleOnListener(eventName: eventName!, data: data as AnyObject)
+                            handleOnListener(eventName: eventName ?? "", data: data as AnyObject)
                         }
                     
                     }


### PR DESCRIPTION
ScClient/client.swift:72: Fatal error: Unexpectedly found nil while unwrapping an Optional value